### PR TITLE
Fix missing dependency error

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,6 @@ version '1.0.0'
 
 -- Dépendances
 dependency 'ox_inventory'
-dependency 'ox_core'
 dependency 'ox_lib'
 dependency 'es_extended'
 dependency 'mysql-async'  -- ou ghmattimysql selon votre config


### PR DESCRIPTION
## Summary
- remove `ox_core` dependency from `fxmanifest.lua`

This resolves the console error complaining that `ox_core` could not be found when starting the `blink` resource.

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68456c93cee48320801acfd4cf1137ee