### PR TITLE
Fix syntax error in server.lua

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -4,7 +4,7 @@ ESX = nil
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
 -- Paramètres par défaut
-local DEFAULT_CAPACITY   = 50_000    -- 50 kg
+local DEFAULT_CAPACITY   = 50000    -- 50 kg
 local DEFAULT_SLOTS      = 16
 local DEFAULT_ALLOWED    = 'coca_leaf'
 local DEFAULT_OUTPUT     = 'cocaine_bag'


### PR DESCRIPTION
## Summary
- correct default capacity value to avoid syntax error

## Testing
- `luac -p server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458a48507c83208993dc493fe7b1d7