### PR TITLE
Fix ox inventory path

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -13,13 +13,11 @@ dependency 'es_extended'
 dependency 'mysql-async'  -- ou ghmattimysql selon votre config
 
 server_scripts {
-    '@ox_inventory/lib/server.lua',  -- si demandé par ox_inventory
     '@mysql-async/lib/MySQL.lua',    -- ou '@ghmattimysql/ghmattimysql.lua'
     'server.lua'
 }
 
 client_scripts {
-    '@ox_inventory/lib/client.lua',  -- si demandé par ox_inventory
     'client.lua'
 }
 

--- a/server.lua
+++ b/server.lua
@@ -3,6 +3,9 @@
 ESX = nil
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
+-- Référence vers les exports d'ox_inventory
+local ox_inventory = exports.ox_inventory
+
 -- Paramètres par défaut
 local DEFAULT_CAPACITY   = 50000    -- 50 kg
 local DEFAULT_SLOTS      = 16


### PR DESCRIPTION
## Summary
- remove old ox_inventory includes
- reference exports.ox_inventory directly for stash helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68458bda56c48320a24c340bff045391