### PR TITLE
Use correct ox_inventory event to open stash

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -111,7 +111,10 @@ CreateThread(function()
                 if dist < 1.5 then
                     ESX.ShowHelpNotification("Appuyez sur ~INPUT_CONTEXT~ pour ouvrir le coffre")
                     if IsControlJustReleased(0, 38) then  -- touche E
-                        TriggerEvent('ox_inventory:openStash', 'blanch_'..id)
+                        TriggerServerEvent('ox_inventory:openInventory', {
+                            type = 'stash',
+                            id   = 'blanch_'..id
+                        })
                     end
                 end
             end


### PR DESCRIPTION
## Summary
- fix stash interaction by using `ox_inventory:openInventory`

## Testing
- `luac` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_68459575c7088320a5530374e9596a04