### PR TITLE
Fix stash not opening

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -111,7 +111,7 @@ CreateThread(function()
                 if dist < 1.5 then
                     ESX.ShowHelpNotification("Appuyez sur ~INPUT_CONTEXT~ pour ouvrir le coffre")
                     if IsControlJustReleased(0, 38) then  -- touche E
-                        TriggerServerEvent('ox_inventory:openInventory', {
+                        exports.ox_inventory:openInventory({
                             type = 'stash',
                             id   = 'blanch_'..id
                         })


### PR DESCRIPTION
## Summary
- call `exports.ox_inventory:openInventory` client-side when pressing **E**

## Testing
- `luacheck` *(fails: command not found)*
- `luac -p client.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684597350e0c8320b192c81bb77e9f11