### PR TITLE
Remove stash item restriction and add inventory column

### DIFF
--- a/Table SQL
+++ b/Table SQL
@@ -7,5 +7,6 @@ CREATE TABLE IF NOT EXISTS `blanchiment_points` (
   `z` DOUBLE NOT NULL,
   `allowed_item` VARCHAR(64) NOT NULL,
   `output_item` VARCHAR(64) NOT NULL,
+  `inventory` TEXT,
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- allow any item in the stash by removing the item filter
- add `inventory` column to SQL table
- save a default inventory item when creating a new blanchiment point

## Testing
- `luac` was not available, so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6845a0f2d09483209c283a37b3c7c2d2