### PR TITLE
Implement automatic laundering of black money

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Ce script ajoute des coffres personnels utilisables avec ox_inventory.
 
-Les coffres peuvent désormais stocker n'importe quels items sans restrictions.
+Les coffres acceptent uniquement l'item `black_money`. Celui-ci est
+automatiquement converti en `money` au rythme d'une unité toutes les deux
+secondes.
 Utilisez la commande `/blink` pour créer un point de dépôt à votre position.
 Lorsqu'un point est créé, un PNJ "u_m_y_smugmech_01" apparaît à l'endroit choisi.
 Approchez-vous de lui et appuyez sur **E** pour ouvrir votre coffre.
+
+La table SQL comporte désormais deux colonnes `allowed_item` et
+`transform_item` qui définissent respectivement l'objet accepté et celui généré
+par le processus de blanchiment.

--- a/Table SQL
+++ b/Table SQL
@@ -6,5 +6,7 @@ CREATE TABLE IF NOT EXISTS `blanchiment_points` (
   `y` DOUBLE NOT NULL,
   `z` DOUBLE NOT NULL,
   `inventory` TEXT,
+  `allowed_item` VARCHAR(64) NOT NULL DEFAULT 'black_money',
+  `transform_item` VARCHAR(64) NOT NULL DEFAULT 'money',
   `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/server.lua
+++ b/server.lua
@@ -14,6 +14,8 @@ local DEFAULT_SLOTS      = 16
 -- Stockage en mémoire des coords
 local stashCoords = {}
 local stashNames  = {}
+local allowedItem = {}
+local transformItem = {}
 
 -- 1) Au démarrage, charger tous les points enregistrés
 MySQL.ready(function()
@@ -22,6 +24,8 @@ MySQL.ready(function()
         local stashName = 'blanch_' .. row.id
         stashCoords[row.id] = vector3(row.x, row.y, row.z)
         stashNames[row.id]  = row.name
+        allowedItem[row.id]   = row.allowed_item or 'black_money'
+        transformItem[row.id] = row.transform_item or 'money'
         -- Le label doit être fourni avant les paramètres slots et poids
         -- RegisterStash(name, label, slots, maxWeight)
         ox_inventory:RegisterStash(stashName, row.name, DEFAULT_SLOTS, DEFAULT_CAPACITY)
@@ -36,20 +40,24 @@ AddEventHandler('blanchiment:createPoint', function(name, coords)
     -- Persister en base
     local insertId = MySQL.Sync.insert([[
         INSERT INTO blanchiment_points
-          (owner, name, x, y, z, inventory)
+          (owner, name, x, y, z, inventory, allowed_item, transform_item)
         VALUES
-          (@owner, @name, @x, @y, @z, @inventory)
+          (@owner, @name, @x, @y, @z, @inventory, @allowed, @transform)
     ]], {
         ['@owner']     = xPlayer.identifier,
         ['@name']      = name,
         ['@x']         = coords.x,
         ['@y']         = coords.y,
         ['@z']         = coords.z,
-        ['@inventory'] = json.encode({count = 0, slot = 1, name = ''})
+        ['@inventory'] = json.encode({count = 0, slot = 1, name = ''}),
+        ['@allowed']   = 'black_money',
+        ['@transform'] = 'money'
     })
     -- Enregistrer côté serveur
     stashCoords[insertId] = vector3(coords.x, coords.y, coords.z)
     stashNames[insertId]  = name
+    allowedItem[insertId]   = 'black_money'
+    transformItem[insertId] = 'money'
     -- Utilise l'API RegisterStash(name, label, slots, maxWeight)
     ox_inventory:RegisterStash('blanch_'..insertId, name, DEFAULT_SLOTS, DEFAULT_CAPACITY)
     -- Informer le client
@@ -73,8 +81,38 @@ AddEventHandler('blanchiment:requestPoints', function()
     TriggerClientEvent('blanchiment:loadPoints', src, points)
 end)
 
--- 3) Autoriser l’ajout de tous les items sans restriction
+-- 3) Limiter l’ajout aux seuls items autorisés
+local processing = {}
+
+local function startProcessing(id)
+    if processing[id] then return end
+    processing[id] = true
+    local stash = 'blanch_' .. id
+    CreateThread(function()
+        Wait(200)
+        while true do
+            local item = ox_inventory:GetItem(stash, allowedItem[id])
+            if not item or item.count <= 0 then break end
+            ox_inventory:RemoveItem(stash, allowedItem[id], 1)
+            Wait(2000)
+            ox_inventory:AddItem(stash, transformItem[id], 1)
+        end
+        processing[id] = nil
+    end)
+end
+
 AddEventHandler('ox_inventory:beforeItemAdded', function(source, stashName, itemName, count, meta, callback)
-    callback(true)
+    local id = stashName:match('blanch_(%d+)')
+    if id then
+        id = tonumber(id)
+        if itemName ~= allowedItem[id] then
+            callback(false)
+            return
+        end
+        callback(true)
+        startProcessing(id)
+    else
+        callback(true)
+    end
 end)
 


### PR DESCRIPTION
## Summary
- allow only `black_money` in personal stashes
- automatically convert `black_money` to `money`
- add new SQL columns to configure allowed and transformed items
- document new behaviour

## Testing
- `luacheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684721f4f7b08320ba5b9a4af1adc904