### PR TITLE
Fix item restriction in stash

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -102,7 +102,8 @@ local function startProcessing(id)
 end
 
 AddEventHandler('ox_inventory:preAddItem', function(source, inventory, itemName, count, slot, metadata, cb)
-    local id = inventory:match('blanch_(%d+)')
+    local invName = type(inventory) == 'table' and inventory.name or inventory
+    local id = invName and invName:match('blanch_(%d+)')
     if id then
         id = tonumber(id)
         if itemName ~= allowedItem[id] then


### PR DESCRIPTION
## Summary
- ensure inventory name is read correctly in item filter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68472f934cb88320ba4acfb5cc939439