### PR TITLE
Spawn random ped from database

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Ce script ajoute des coffres personnels utilisables avec ox_inventory.
 Les coffres acceptent désormais tous les items sans restriction et ne
 possèdent pas de limite de poids (capacité à `0`).
 Utilisez la commande `/blink` pour créer un point de dépôt à votre position.
-Lorsqu'un point est créé, un PNJ "u_m_y_smugmech_01" apparaît à l'endroit choisi.
+Lorsqu'un point est créé, un PNJ aléatoire (issu de la table `blanchiment_ped`)
+apparaît à l'endroit choisi.
 Approchez-vous de lui et appuyez sur **E** pour ouvrir votre coffre.
 
 La table SQL a été simplifiée et ne contient plus les colonnes `allowed_item`

--- a/client.lua
+++ b/client.lua
@@ -8,9 +8,10 @@ CreateThread(function()
         Wait(0)
     end
 end)
-local stashCoords = {}  -- id → vector3
-local stashNames  = {}  -- id → string
-local stashPeds   = {}  -- id → ped handle
+local stashCoords    = {}  -- id → vector3
+local stashNames     = {}  -- id → string
+local stashPedModels = {}  -- id → string
+local stashPeds      = {}  -- id → ped handle
 
 -- Charger les points enregistrés quand le joueur se connecte
 RegisterNetEvent('esx:playerLoaded')
@@ -31,8 +32,8 @@ local function KeyboardInput(text, example, maxLength)
 end
 
 -- Spawn a ped used for interaction
-local function SpawnStashPed(id, coords)
-    local model = GetHashKey('u_m_y_smugmech_01')
+local function SpawnStashPed(id, coords, pedModel)
+    local model = GetHashKey(pedModel or 'u_m_y_smugmech_01')
     RequestModel(model)
     while not HasModelLoaded(model) do
         Wait(0)
@@ -96,10 +97,11 @@ end)
 
 -- 2) Réception d’un point créé : stocke coords + blip privé
 RegisterNetEvent('blanchiment:pointCreated')
-AddEventHandler('blanchiment:pointCreated', function(id, coords, name)
-    stashCoords[id] = vector3(coords.x, coords.y, coords.z)
-    stashNames[id]  = name
-    SpawnStashPed(id, coords)
+AddEventHandler('blanchiment:pointCreated', function(id, coords, name, pedModel)
+    stashCoords[id]    = vector3(coords.x, coords.y, coords.z)
+    stashNames[id]     = name
+    stashPedModels[id] = pedModel or 'u_m_y_smugmech_01'
+    SpawnStashPed(id, coords, stashPedModels[id])
     -- Création du blip
     local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
     SetBlipSprite(blip, 521)
@@ -114,9 +116,10 @@ end)
 RegisterNetEvent('blanchiment:loadPoints')
 AddEventHandler('blanchiment:loadPoints', function(points)
     for _, data in ipairs(points) do
-        stashCoords[data.id] = vector3(data.x, data.y, data.z)
-        stashNames[data.id]  = data.name
-        SpawnStashPed(data.id, vector3(data.x, data.y, data.z))
+        stashCoords[data.id]    = vector3(data.x, data.y, data.z)
+        stashNames[data.id]     = data.name
+        stashPedModels[data.id] = data.ped or 'u_m_y_smugmech_01'
+        SpawnStashPed(data.id, vector3(data.x, data.y, data.z), stashPedModels[data.id])
         local blip = AddBlipForCoord(data.x, data.y, data.z)
         SetBlipSprite(blip, 521)
         SetBlipColour(blip, 1)


### PR DESCRIPTION
## Summary
- choose henchman model randomly from `blanchiment_ped`
- keep ped model in memory and send it to clients when creating/loading points
- spawn peds using the chosen model
- update documentation

## Testing
- `luac -p client.lua` *(fails: command not found)*
- `luac -p server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473f5bed808320b18909b709bc408b