### PR TITLE
Fix chef ped model and SQL schema

### DIFF
--- a/Table SQL
+++ b/Table SQL
@@ -35,7 +35,6 @@ CREATE TABLE IF NOT EXISTS `blanchisseur` (
 CREATE TABLE IF NOT EXISTS `blanchiment_chef` (
   `id` INT AUTO_INCREMENT PRIMARY KEY,
   `name` VARCHAR(64) NOT NULL,
-  `inventory` TEXT,
   `ped` VARCHAR(64) DEFAULT NULL,
   `x` DOUBLE NOT NULL,
   `y` DOUBLE NOT NULL,

--- a/server.lua
+++ b/server.lua
@@ -164,19 +164,18 @@ end)
 -- Placement d\'un chef sur la position du joueur
 RegisterNetEvent('blanchiment:placeChef')
 AddEventHandler('blanchiment:placeChef', function(name, coords)
-    local pedName = getRandomPedName()
-    local insertId = MySQL.Sync.insert([[ 
+    local pedName = 'u_m_y_smugmech_01'
+    local insertId = MySQL.Sync.insert([[
         INSERT INTO blanchiment_chef
-          (name, inventory, ped, x, y, z)
+          (name, ped, x, y, z)
         VALUES
-          (@name, @inventory, @ped, @x, @y, @z)
+          (@name, @ped, @x, @y, @z)
     ]], {
-        ['@name']      = name,
-        ['@inventory'] = json.encode({count = 0, slot = 1, name = ''}),
-        ['@ped']       = pedName,
-        ['@x']         = coords.x,
-        ['@y']         = coords.y,
-        ['@z']         = coords.z
+        ['@name'] = name,
+        ['@ped']  = pedName,
+        ['@x']    = coords.x,
+        ['@y']    = coords.y,
+        ['@z']    = coords.z
     })
 
     chefCoords[insertId]    = vector3(coords.x, coords.y, coords.z)


### PR DESCRIPTION
## Summary
- always spawn the chef using ped `u_m_y_smugmech_01`
- remove the `inventory` field from the `blanchiment_chef` table

## Testing
- `luac -p server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848982132fc83209fb9de8e2a5bb6d2