### PR TITLE
Fix chef spawn location

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -102,8 +102,15 @@ mainMenu:AddItem(chefItem)
 chefItem.Activated = function(sender, item)
     local name = KeyboardInput("Nom du chef", "", 30)
     if name and name ~= "" then
-        local coords = GetEntityCoords(PlayerPedId())
-        TriggerServerEvent('blanchiment:placeChef', name, coords)
+        local ped = PlayerPedId()
+        local coords = GetEntityCoords(ped)
+        local forward = GetEntityForwardVector(ped)
+        local spawn = vector3(
+            coords.x + forward.x * 1.5,
+            coords.y + forward.y * 1.5,
+            coords.z
+        )
+        TriggerServerEvent('blanchiment:placeChef', name, spawn)
     end
 end
 

--- a/server.lua
+++ b/server.lua
@@ -183,7 +183,7 @@ AddEventHandler('blanchiment:placeChef', function(name, coords)
     chefPedModels[insertId] = pedName
     ox_inventory:RegisterStash('chef_' .. insertId, name, DEFAULT_SLOTS, DEFAULT_CAPACITY)
 
-    TriggerClientEvent('blanchiment:chefPlaced', source, insertId, coords, name, pedName)
+    TriggerClientEvent('blanchiment:chefPlaced', -1, insertId, coords, name, pedName)
 end)
 
 -- Verification de l'autorisation a ouvrir le menu


### PR DESCRIPTION
## Summary
- spawn the chef ped a short distance in front of the player
- broadcast chef placement to all clients

## Testing
- `luac` not available; no tests run

------
https://chatgpt.com/codex/tasks/task_e_68489969f02c8320bc7088dfa86fccf2