### PR TITLE
Add chef interaction menu

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -66,6 +66,21 @@ end
 local MenuPool = NativeUI.CreatePool()
 local mainMenu = NativeUI.CreateMenu("Blanchiment", "Gestion des points")
 MenuPool:Add(mainMenu)
+local chefMenu = NativeUI.CreateMenu("Chef", "Choisissez un coffre")
+MenuPool:Add(chefMenu)
+
+local function OpenChefMenu()
+    chefMenu:Clear()
+    for id, name in pairs(stashNames) do
+        local item = NativeUI.CreateItem(name, '')
+        chefMenu:AddItem(item)
+        item.Activated = function()
+            exports.ox_inventory:openInventory('stash', { id = 'blanch_' .. id })
+        end
+    end
+    MenuPool:RefreshIndex()
+    chefMenu:Visible(true)
+end
 
 -- Item de création de point (renommé)
 local createItem = NativeUI.CreateItem("envoyer un homme de main", "Place un nouveau coffre pour vous.")
@@ -100,18 +115,15 @@ end
 local chefItem = NativeUI.CreateItem("Placer le chef", "Place le chef a votre position")
 mainMenu:AddItem(chefItem)
 chefItem.Activated = function(sender, item)
-    local name = KeyboardInput("Nom du chef", "", 30)
-    if name and name ~= "" then
-        local ped = PlayerPedId()
-        local coords = GetEntityCoords(ped)
-        local forward = GetEntityForwardVector(ped)
-        local spawn = vector3(
-            coords.x + forward.x * 1.5,
-            coords.y + forward.y * 1.5,
-            coords.z
-        )
-        TriggerServerEvent('blanchiment:placeChef', name, spawn)
-    end
+    local ped = PlayerPedId()
+    local coords = GetEntityCoords(ped)
+    local forward = GetEntityForwardVector(ped)
+    local spawn = vector3(
+        coords.x + forward.x * 1.5,
+        coords.y + forward.y * 1.5,
+        coords.z
+    )
+    TriggerServerEvent('blanchiment:placeChef', spawn)
 end
 
 MenuPool:RefreshIndex()
@@ -228,11 +240,9 @@ CreateThread(function()
             if DoesEntityExist(pedHandle) then
                 local dist = #(pos - GetEntityCoords(pedHandle))
                 if dist < 2.0 then
-                    ESX.ShowHelpNotification("Appuyez sur ~INPUT_CONTEXT~ pour ouvrir le coffre")
+                    ESX.ShowHelpNotification("Appuyez sur ~INPUT_CONTEXT~ pour parler au chef")
                     if IsControlJustReleased(0, 38) then
-                        exports.ox_inventory:openInventory('stash', {
-                            id = 'chef_' .. id
-                        })
+                        OpenChefMenu()
                     end
                 end
             end

--- a/server.lua
+++ b/server.lua
@@ -163,15 +163,16 @@ end)
 
 -- Placement d\'un chef sur la position du joueur
 RegisterNetEvent('blanchiment:placeChef')
-AddEventHandler('blanchiment:placeChef', function(name, coords)
+AddEventHandler('blanchiment:placeChef', function(coords)
     local pedName = 'u_m_y_smugmech_01'
+    local chefName = 'chef'
     local insertId = MySQL.Sync.insert([[
         INSERT INTO blanchiment_chef
           (name, ped, x, y, z)
         VALUES
           (@name, @ped, @x, @y, @z)
     ]], {
-        ['@name'] = name,
+        ['@name'] = chefName,
         ['@ped']  = pedName,
         ['@x']    = coords.x,
         ['@y']    = coords.y,
@@ -179,11 +180,11 @@ AddEventHandler('blanchiment:placeChef', function(name, coords)
     })
 
     chefCoords[insertId]    = vector3(coords.x, coords.y, coords.z)
-    chefNames[insertId]     = name
+    chefNames[insertId]     = chefName
     chefPedModels[insertId] = pedName
-    ox_inventory:RegisterStash('chef_' .. insertId, name, DEFAULT_SLOTS, DEFAULT_CAPACITY)
+    ox_inventory:RegisterStash('chef_' .. insertId, chefName, DEFAULT_SLOTS, DEFAULT_CAPACITY)
 
-    TriggerClientEvent('blanchiment:chefPlaced', -1, insertId, coords, name, pedName)
+    TriggerClientEvent('blanchiment:chefPlaced', -1, insertId, coords, chefName, pedName)
 end)
 
 -- Verification de l'autorisation a ouvrir le menu


### PR DESCRIPTION
## Summary
- make chef always named `chef`
- simplify chef placement without asking for a name
- add a new menu when speaking to the chef listing all stashes
- pressing **E** near the chef now opens that menu

## Testing
- `lua` command unavailable in container

------
https://chatgpt.com/codex/tasks/task_e_68489cc473cc83209adf3c090c462ed9