### PR TITLE
Update ped despawn behavior

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -47,6 +47,15 @@ local function SpawnStashPed(id, coords, pedModel)
     SetEntityInvincible(ped, true)
     SetBlockingOfNonTemporaryEvents(ped, true)
     stashPeds[id] = ped
+
+    -- Automatically remove the ped after one minute
+    CreateThread(function()
+        Wait(60000)
+        if DoesEntityExist(ped) then
+            DeleteEntity(ped)
+        end
+        stashPeds[id] = nil
+    end)
 end
 
 local function SpawnChefPed(id, coords, pedModel)
@@ -244,13 +253,6 @@ CreateThread(function()
                             exports.ox_inventory:openInventory('stash', {
                                 id = 'blanch_' .. id
                             })
-                            stashPeds[id] = nil
-                            CreateThread(function()
-                                Wait(30000) -- ped disappear 30s after opening
-                                if DoesEntityExist(pedHandle) then
-                                    DeleteEntity(pedHandle)
-                                end
-                            end)
                         end
                     end
                 end


### PR DESCRIPTION
## Summary
- let spawned ped disappear automatically after 1 minute
- keep ped usable until it despawns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849cbf851d48320b2965fb4bfd0b5de